### PR TITLE
fix: monochrome icon is smaller and blurred

### DIFF
--- a/lib/src/android.dart
+++ b/lib/src/android.dart
@@ -116,9 +116,9 @@ void _createAndroidAdaptiveIcon({
     _removeAdaptiveRound(androidIcons);
   }
   if (monochrome != null) {
-    _createAdaptiveMonochrome(androidIcons, monochrome);
+    _createAdaptiveMonochrome(adaptiveIcons, monochrome);
   } else {
-    _removeAdaptiveMonochrome(androidIcons);
+    _removeAdaptiveMonochrome(adaptiveIcons);
   }
 }
 


### PR DESCRIPTION
Monochrome icons are part of adaptive icons family and hence should have the same size as adaptive icons.

Else they appear smaller than recommended and also blurred.