### PR TITLE
Correctly document supported SDK versions to Dart 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   yaml: ^3.1.2
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
The latest version of this package currently requires a Flutter version that also supports Dart 3 (e.g. Flutter 3.10+). Running pub get with lower versions of Flutter fails with package resolution conflict error that is not easy to understand. This change correctly documents the necessary SDK to successfully resolve this package, and fails with a meaningful error if it doesn't.