### PR TITLE
Adds favicon.ico to web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-
+## 2.1.5
+- Adds favicon.ico to web
 ## 2.1.4
 
 - Adds pub topics to package metadata

--- a/lib/src/web.dart
+++ b/lib/src/web.dart
@@ -35,6 +35,8 @@ void _createWebFavicon({required String imagePath}) {
 
   final webFavicon = WebIconTemplate(name: 'favicon.png', size: 16);
   _saveFaviconImageWeb(webFavicon, image);
+  final webFaviconIco = WebIconTemplate(name: 'favicon.ico', size: 16);
+  _saveFaviconImageWeb(webFaviconIco, image);
   CliLogger.success('Generated favicon image', level: CliLoggerLevel.two);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ maintainer: Mrr Hak
 homepage: https://mrrhak.com
 repository: https://github.com/mrrhak/icons_launcher
 issue_tracker: https://github.com/mrrhak/icons_launcher/issues
-version: 2.1.4
+version: 2.1.5
 funding:
   - https://ko-fi.com/mrrhak
 screenshots:


### PR DESCRIPTION
fixes google chrome create shortcut 

without it 
<img width="453" alt="image" src="https://github.com/mrrhak/icons_launcher/assets/25157308/d2db54ae-e639-4111-845e-745b33ec0c37">

with it 

<img width="456" alt="image" src="https://github.com/mrrhak/icons_launcher/assets/25157308/626140a1-637b-4254-b7d7-a75448fad2d6">

