### PR TITLE
fix(macos): contents json always generated in default folder using flavors

### DIFF
--- a/lib/src/macos.dart
+++ b/lib/src/macos.dart
@@ -44,7 +44,7 @@ void createMacOSIcons({required String imagePath}) {
     }
   }
   CliLogger.success('Generated app icon images', level: CliLoggerLevel.two);
-  AppleAppIconType(images: macosIcons, assetPath: MACOS_DEFAULT_APP_ICON_DIR)
+  AppleAppIconType(images: macosIcons, assetPath: _flavorHelper.macOSAssetsAppIconFolder)
       .saveContentsJson();
 }
 

--- a/lib/utils/template.dart
+++ b/lib/utils/template.dart
@@ -161,7 +161,7 @@ class MacOSIconTemplate extends AppleIconTemplate {
   });
 
   @override
-  String get filename => '${MACOS_DEFAULT_ICON_NAME}_$scaledSize.png';
+  String get filename => '${MACOS_DEFAULT_ICON_NAME}_$scaledSize12.png';
 
   @override
   Map<String, dynamic> toJson() => <String, String>{


### PR DESCRIPTION
Fix for #78 