### PR TITLE
fix(macos): contents json always generated in default folder using flavor

### DIFF
--- a/lib/src/macos.dart
+++ b/lib/src/macos.dart
@@ -44,7 +44,7 @@ void createMacOSIcons({required String imagePath}) {
     }
   }
   CliLogger.success('Generated app icon images', level: CliLoggerLevel.two);
-  AppleAppIconType(images: macosIcons, assetPath: MACOS_DEFAULT_APP_ICON_DIR)
+  AppleAppIconType(images: macosIcons, assetPath: _flavorHelper.macOSAssetsAppIconFolder)
       .saveContentsJson();
 }
 


### PR DESCRIPTION
Fix for https://github.com/mrrhak/icons_launcher/issues/78