### PR TITLE
feat(ci): add Dependabot configuration and update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+updates:
+  # GetHub Actions Workflow
+  - package-ecosystem: 'github-actions'
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: '/'
+    target-branch: 'master'
+    schedule:
+      interval: 'monthly' # Can be "daily", "weekly", "monthly"
+      time: '08:00' # Time of day in 24-hour format (UTC time)
+      timezone: 'Asia/Phnom_Penh' # Set a specific timezone
+    labels:
+      - 'workflows'
+
+  # Pub Package
+  - package-ecosystem: 'pub'
+    directory: '/'
+    target-branch: 'master'
+    schedule:
+      interval: 'monthly' # Can be "daily", "weekly", "monthly"
+      time: '08:00' # Time of day in 24-hour format (UTC time)
+      timezone: 'Asia/Phnom_Penh' # Set a specific timezone
+    labels:
+      - 'dependencies'

--- a/.github/workflows/format-analyze-test.yml
+++ b/.github/workflows/format-analyze-test.yml
@@ -10,7 +10,7 @@ jobs:
   format-analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1.7.1
 
       - name: Install Dependencies
@@ -26,6 +26,6 @@ jobs:
         run: dart test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: ">> Dart package <<"
-        uses: k-paxian/dart-package-publisher@v1.6
+        uses: k-paxian/dart-package-publisher@v1.6.2
         with:
           accessToken: ${{ secrets.OAUTH_ACCESS_TOKEN }}
           refreshToken: ${{ secrets.OAUTH_REFRESH_TOKEN }}


### PR DESCRIPTION
- Feat(web): add `maskable_image_path` support for web icons generator
- Feat(web): add `favicon_output_extension` support for web icons generator with `.ico`, `.png` and default `.png` 
- Feat(linux): add `snapcraft.yaml` and update `desktop` file generator
- Refactor(macos): update macos icon generator to follow new flutter template
- Chore(log): improve CLI output messages and formatting
- Chore(dart): bump dart sdk min version to `v3.10.0`
- Chore(image): bump image package from `v4.5.4` to `v4.8.0`
- Chore(path): bump path package from `v1.8.2` to `v1.9.1`
- Chore(universal_io): bump universal_io package from `v2.2.2` to `v2.3.1`
- Chore(build_runner): bump build_runner package from `v2.8.0` to `v2.13.1`
- Chore(build_version): bump build_version package from `v2.1.3` to `v2.2.0`
- Chore(lints): bump lints package from `v6.0.0` to `v6.1.0`
- Chore(test): bump test package from `v1.26.3` to `v1.31.0`